### PR TITLE
Fix calendar unadjusted

### DIFF
--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -162,11 +162,10 @@ namespace QuantLib {
             if (endOfMonth && isEndOfMonth(d))
                 if (c == Unadjusted){
                     // move to end of calendar day if using Unadjusted convention
-                    return Date::endOfMonth(d);
+                    return Date::endOfMonth(d1);
                 } else {
                     return Calendar::endOfMonth(d1);
                 }
-
             return adjust(d1, c);
         }
     }

--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -160,7 +160,12 @@ namespace QuantLib {
 
             // we are sure the unit is Months or Years
             if (endOfMonth && isEndOfMonth(d))
-                return Calendar::endOfMonth(d1);
+                if (c == Unadjusted){
+                    // move to end of calendar day if using Unadjusted convention
+                    return Date::endOfMonth(d);
+                } else {
+                    return Calendar::endOfMonth(d1);
+                }
 
             return adjust(d1, c);
         }

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -376,6 +376,28 @@ BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfMonth) {
                     "got " << firstCoupon->referencePeriodStart());
 }
 
+BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfCalendarMonth) {
+    BOOST_TEST_MESSAGE("Testing irregular first coupon reference dates at end of calendar month with end of month enabled...");
+    Schedule schedule =
+        MakeSchedule()
+        .from(Date(30, September, 2017)).to(Date(2, April, 2018))
+        .withFrequency(Semiannual)
+        .withConvention(Unadjusted)
+        .endOfMonth()
+        .backwards();
+
+    Leg leg = FixedRateLeg(schedule)
+        .withNotionals(100.0)
+        .withCouponRates(0.01875, ActualActual(ActualActual::ISMA));
+
+    ext::shared_ptr<Coupon> firstCoupon =
+        ext::dynamic_pointer_cast<Coupon>(leg.front());
+
+    if (firstCoupon->referencePeriodStart() != Date(30, September, 2017))
+        BOOST_ERROR("Expected reference start date at end of calendar day of the month, "
+                    "got " << firstCoupon->referencePeriodStart());
+}
+
 BOOST_AUTO_TEST_CASE(testIrregularLastCouponReferenceDatesAtEndOfMonth) {
     BOOST_TEST_MESSAGE("Testing irregular last coupon reference dates with end of month enabled...");
     Schedule schedule =

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -380,9 +380,13 @@ BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfCalendarMonth)
     BOOST_TEST_MESSAGE("Testing irregular first coupon reference dates at end of calendar month with end of month enabled...");
     Schedule schedule =
         MakeSchedule()
-        .from(Date(30, September, 2017)).to(Date(2, April, 2018))
-        .withFrequency(Semiannual)
+        .withCalendar(UnitedStates(UnitedStates::GovernmentBond))
+        .from(Date(30, September, 2017)).to(Date(30, September, 2022))
+        .withTenor(6*Months)
         .withConvention(Unadjusted)
+        .withTerminationDateConvention(Unadjusted)
+        .withFirstDate(Date(31, March, 2018))
+        .withNextToLastDate(Date(31, March, 2022))
         .endOfMonth()
         .backwards();
 
@@ -390,12 +394,18 @@ BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfCalendarMonth)
         .withNotionals(100.0)
         .withCouponRates(0.01875, ActualActual(ActualActual::ISMA));
 
+    for (const auto& elem : leg) {
+        BOOST_TEST_MESSAGE("Reference Period: " << ext::dynamic_pointer_cast<Coupon>(elem)->referencePeriodStart() << " - " << ext::dynamic_pointer_cast<Coupon>(elem)->referencePeriodEnd());
+        BOOST_TEST_MESSAGE("Amount: " << ext::dynamic_pointer_cast<Coupon>(elem)->amount());
+    }
+
     ext::shared_ptr<Coupon> firstCoupon =
         ext::dynamic_pointer_cast<Coupon>(leg.front());
-
     if (firstCoupon->referencePeriodStart() != Date(30, September, 2017))
         BOOST_ERROR("Expected reference start date at end of calendar day of the month, "
                     "got " << firstCoupon->referencePeriodStart());
+    // Expect first cashflow to be 0.9375
+    BOOST_TEST(firstCoupon->amount() == 0.9375, boost::test_tools::tolerance(0.0001));
 }
 
 BOOST_AUTO_TEST_CASE(testIrregularLastCouponReferenceDatesAtEndOfMonth) {


### PR DESCRIPTION
This PR resolves `"https://github.com/lballabio/QuantLib/issues/1910"`

In Calendar::advance(), the return date will be moved to end of business day if endOfMonth && isEndOfMonth(d) is True. However, isEndOfMonth(d) is True when d is on or after the end of business day, which introduces a discrepancy between d and the return date.

This PR fixes this behavior by returning the end of calendar date when convention is Unadjusted.

I added a unit test to ensure this behaves correctly for a US treasury bond. The ref start date should be end of calendar date and the cashflow should match the real-world cashflow.